### PR TITLE
Work on Guaranteed index false positives.

### DIFF
--- a/src/main/java/org/jfree/chart/axis/CompassFormat.java
+++ b/src/main/java/org/jfree/chart/axis/CompassFormat.java
@@ -113,7 +113,7 @@ public class CompassFormat extends NumberFormat {
         if (direction < 0.0) {
             direction = direction + 360.0;
         }
-        @SuppressWarnings({"index", "value"}) // Math.floor needs annotations?
+        @SuppressWarnings({"index", "value"}) // Needs @DoubleRange
         @IntRange(from = 0, to = 15) int index = ((int) Math.floor(direction / 11.25) + 1) / 2;
         return directions[index];
     }

--- a/src/main/java/org/jfree/chart/plot/CategoryPlot.java
+++ b/src/main/java/org/jfree/chart/plot/CategoryPlot.java
@@ -2193,7 +2193,7 @@ public class CategoryPlot extends Plot implements ValueAxisPlot, Pannable,
         // get the legend items for the datasets...
         for (CategoryDataset dataset: this.datasets.values()) {
             if (dataset != null) {
-                @SuppressWarnings("index") // guaranteed index: indexOf cannot return -1 here because we're looking up the indexOf an element we already know is in the dataset
+                @SuppressWarnings("index") // rewrite guaranteed index: indexOf cannot return -1 here because we're looking up the indexOf an element we already know is in the dataset
                 @NonNegative int datasetIndex = indexOf(dataset);
                 CategoryItemRenderer renderer = getRenderer(datasetIndex);
                 if (renderer != null) {
@@ -3405,7 +3405,7 @@ public class CategoryPlot extends Plot implements ValueAxisPlot, Pannable,
             // reserve space for any domain axes...
             for (CategoryAxis xAxis : this.domainAxes.values()) {
                 if (xAxis != null) {
-                    @SuppressWarnings("index") // guaranteed index: xAxis is guaranteed to be in the set, so IndexOf returns NN
+                    @SuppressWarnings("index") // rewrite guaranteed index: xAxis is guaranteed to be in the set, so IndexOf returns NN
                     @NonNegative int i = getDomainAxisIndex(xAxis);
                     RectangleEdge edge = getDomainAxisEdge(i);
                     space = xAxis.reserveSpace(g2, this, plotArea, edge, space);
@@ -3450,7 +3450,7 @@ public class CategoryPlot extends Plot implements ValueAxisPlot, Pannable,
             // reserve space for the range axes (if any)...
             for (ValueAxis yAxis : this.rangeAxes.values()) {
                 if (yAxis != null) {
-                    @SuppressWarnings("index") // guaranteed index: yAxis is guaranteed to be in the set, so indexOf returns NN
+                    @SuppressWarnings("index") // rewrite guaranteed index: yAxis is guaranteed to be in the set, so indexOf returns NN
                     @NonNegative int i = findRangeAxisIndex(yAxis);
                     RectangleEdge edge = getRangeAxisEdge(i);
                     space = yAxis.reserveSpace(g2, this, plotArea, edge, space);
@@ -3619,12 +3619,12 @@ public class CategoryPlot extends Plot implements ValueAxisPlot, Pannable,
 
         // draw the markers...
         for (CategoryItemRenderer renderer : this.renderers.values()) {
-            @SuppressWarnings("index") // guaranteed index: renderer is one of the renderers of this object, so getIndexOf must return nonnegative
+            @SuppressWarnings("index") // rewrite guaranteed index: renderer is one of the renderers of this object, so getIndexOf must return nonnegative
             @NonNegative int i = getIndexOf(renderer);
             drawDomainMarkers(g2, dataArea, i, Layer.BACKGROUND);
         }
         for (CategoryItemRenderer renderer : this.renderers.values()) {
-            @SuppressWarnings("index") // guaranteed index: renderer is one of the renderers of this object, so getIndexOf must return nonnegative
+            @SuppressWarnings("index") // rewrite guaranteed index: renderer is one of the renderers of this object, so getIndexOf must return nonnegative
             @NonNegative int i = getIndexOf(renderer);
             drawRangeMarkers(g2, dataArea, i, Layer.BACKGROUND);
         }
@@ -3803,7 +3803,7 @@ public class CategoryPlot extends Plot implements ValueAxisPlot, Pannable,
         // add domain axes to lists...
         for (CategoryAxis xAxis : this.domainAxes.values()) {
             if (xAxis != null) {
-                @SuppressWarnings("index") // guaranteed index: xAxis is guaranteed to have an index, so getDomainAxisIndex return NN
+                @SuppressWarnings("index") // rewrite guaranteed index: xAxis is guaranteed to have an index, so getDomainAxisIndex return NN
                 @NonNegative int index = getDomainAxisIndex(xAxis);
                 axisCollection.add(xAxis, getDomainAxisEdge(index));
             }
@@ -3812,7 +3812,7 @@ public class CategoryPlot extends Plot implements ValueAxisPlot, Pannable,
         // add range axes to lists...
         for (ValueAxis yAxis : this.rangeAxes.values()) {
             if (yAxis != null) {
-                @SuppressWarnings("index") // guaranteed index: yAxis is guaranteed to have an index, so getRangeAxisIndex return NN
+                @SuppressWarnings("index") // rewrite guaranteed index: yAxis is guaranteed to have an index, so getRangeAxisIndex return NN
                 @NonNegative int index = findRangeAxisIndex(yAxis);
                 axisCollection.add(yAxis, getRangeAxisEdge(index));
             }

--- a/src/main/java/org/jfree/chart/plot/CategoryPlot.java
+++ b/src/main/java/org/jfree/chart/plot/CategoryPlot.java
@@ -2425,10 +2425,9 @@ public class CategoryPlot extends Plot implements ValueAxisPlot, Pannable,
     public void clearDomainMarkers() {
         if (this.backgroundDomainMarkers != null) {
             
-                    Set<@NonNegative Integer> keys = this.backgroundDomainMarkers.keySet();
-            Iterator iterator = keys.iterator();
+            Set<@NonNegative Integer> keys = this.backgroundDomainMarkers.keySet();
+            Iterator<@NonNegative Integer> iterator = keys.iterator();
             while (iterator.hasNext()) {
-                @SuppressWarnings({"index", "value"}) // iterator over a set of nonnegative integers always returns a nonnegative integer?
                 @NonNegative Integer key = (Integer) iterator.next();
                 clearDomainMarkers(key.intValue());
             }
@@ -2437,9 +2436,8 @@ public class CategoryPlot extends Plot implements ValueAxisPlot, Pannable,
         if (this.foregroundDomainMarkers != null) {
 
             Set<@NonNegative Integer> keys = this.foregroundDomainMarkers.keySet();
-            Iterator iterator = keys.iterator();
+            Iterator<@NonNegative Integer> iterator = keys.iterator();
             while (iterator.hasNext()) {
-                @SuppressWarnings({"index", "value"}) // iterator over a set of nonnegative integers always returns a nonnegative integer?
                 @NonNegative Integer key = (Integer) iterator.next();
                 clearDomainMarkers(key.intValue());
             }
@@ -2702,9 +2700,8 @@ public class CategoryPlot extends Plot implements ValueAxisPlot, Pannable,
         if (this.backgroundRangeMarkers != null) {
 
                     Set<@NonNegative Integer> keys = this.backgroundRangeMarkers.keySet();
-            Iterator iterator = keys.iterator();
+            Iterator<@NonNegative Integer> iterator = keys.iterator();
             while (iterator.hasNext()) {
-                @SuppressWarnings({"index", "value"}) // iterator over a set of nonnegative integers always returns a nonnegative integer?
                 @NonNegative Integer key = (Integer) iterator.next();
                 clearRangeMarkers(key.intValue());
             }
@@ -2713,9 +2710,8 @@ public class CategoryPlot extends Plot implements ValueAxisPlot, Pannable,
         if (this.foregroundRangeMarkers != null) {
 
                     Set<@NonNegative Integer> keys = this.foregroundRangeMarkers.keySet();
-            Iterator iterator = keys.iterator();
+            Iterator<@NonNegative Integer> iterator = keys.iterator();
             while (iterator.hasNext()) {
-                @SuppressWarnings({"index", "value"}) // iterator over a set of nonnegative integers always returns a nonnegative integer?
                 @NonNegative Integer key = (Integer) iterator.next();
                 clearRangeMarkers(key.intValue());
             }

--- a/src/main/java/org/jfree/chart/plot/PolarPlot.java
+++ b/src/main/java/org/jfree/chart/plot/PolarPlot.java
@@ -259,7 +259,7 @@ public class PolarPlot extends Plot implements ValueAxisPlot, Zoomable,
      * entry for a dataset, it is assumed to map to the primary domain axis
      * (index = 0).
      */
-    private Map datasetToAxesMap;
+    private Map<@NonNegative Integer, List<@NonNegative Integer>> datasetToAxesMap;
 
     /**
      * Default constructor.
@@ -288,7 +288,7 @@ public class PolarPlot extends Plot implements ValueAxisPlot, Zoomable,
         this.angleTickUnit = new NumberTickUnit(DEFAULT_ANGLE_TICK_UNIT_SIZE);
 
         this.axes = new ObjectList();
-        this.datasetToAxesMap = new TreeMap();
+        this.datasetToAxesMap = new TreeMap<>();
         this.axes.set(0, radiusAxis);
         if (radiusAxis != null) {
             radiusAxis.setPlot(this);
@@ -1250,13 +1250,12 @@ public class PolarPlot extends Plot implements ValueAxisPlot, Zoomable,
      *
      * @since 1.0.14
      */
-    public void mapDatasetToAxes(@NonNegative int index, List axisIndices) {
+    public void mapDatasetToAxes(@NonNegative int index, List<@NonNegative Integer> axisIndices) {
         if (index < 0) {
             throw new IllegalArgumentException("Requires 'index' >= 0.");
         }
         checkAxisIndices(axisIndices);
-        Integer key = new Integer(index);
-        this.datasetToAxesMap.put(key, new ArrayList(axisIndices));
+        this.datasetToAxesMap.put(index, new ArrayList<>(axisIndices));
         // fake a dataset change event to update axes...
         datasetChanged(new DatasetChangeEvent(this, getDataset(index)));
     }
@@ -1303,12 +1302,10 @@ public class PolarPlot extends Plot implements ValueAxisPlot, Zoomable,
      */
     public ValueAxis getAxisForDataset(@NonNegative int index) {
         ValueAxis valueAxis;
-        List axisIndices = (List) this.datasetToAxesMap.get(
-                new Integer(index));
+        List<@NonNegative Integer> axisIndices = this.datasetToAxesMap.get(index);
         if (axisIndices != null) {
             // the first axis in the list is used for data <--> Java2D
-            @SuppressWarnings("index") // guaranteed index: axesIndices[0] is always NN
-            @NonNegative int axisIndex = ((Integer) axisIndices.get(0)).intValue();
+            @NonNegative int axisIndex = axisIndices.get(0);
             valueAxis = getAxis(axisIndex);
         }
         else {

--- a/src/main/java/org/jfree/chart/plot/XYPlot.java
+++ b/src/main/java/org/jfree/chart/plot/XYPlot.java
@@ -3058,7 +3058,7 @@ public class XYPlot extends Plot implements ValueAxisPlot, Pannable, Zoomable,
             // reserve space for the domain axes...
             for (ValueAxis axis: this.domainAxes.values()) {
                 if (axis != null) {
-                    @SuppressWarnings("index") // guaranteed index: axis is guaranteed to be a domain axis, so findDomainAxisIndex will return NN
+                    @SuppressWarnings("index") // rewrite guaranteed index: axis is guaranteed to be a domain axis, so findDomainAxisIndex will return NN
                     RectangleEdge edge = getDomainAxisEdge(
                             findDomainAxisIndex(axis));
                     space = axis.reserveSpace(g2, this, plotArea, edge, space);
@@ -3105,7 +3105,7 @@ public class XYPlot extends Plot implements ValueAxisPlot, Pannable, Zoomable,
             // reserve space for the range axes...
             for (ValueAxis axis: this.rangeAxes.values()) {
                 if (axis != null) {
-                    @SuppressWarnings("index") // guaranteed index: axis is guaranteed to be a range axis, so findRangeAxisIndex will return NN
+                    @SuppressWarnings("index") // rewrite guaranteed index: axis is guaranteed to be a range axis, so findRangeAxisIndex will return NN
                      RectangleEdge edge = getRangeAxisEdge(
                             findRangeAxisIndex(axis));
                     space = axis.reserveSpace(g2, this, plotArea, edge, space);
@@ -3275,12 +3275,12 @@ public class XYPlot extends Plot implements ValueAxisPlot, Pannable, Zoomable,
 
         // draw the markers that are associated with a specific dataset...
         for (XYDataset dataset: this.datasets.values()) {
-            @SuppressWarnings("index") // guaranteed index: dataset is definitely a valid dataset, so its index will be nonnegative
+            @SuppressWarnings("index") // rewrite guaranteed index: dataset is definitely a valid dataset, so its index will be nonnegative
             @NonNegative int datasetIndex = indexOf(dataset);
             drawDomainMarkers(g2, dataArea, datasetIndex, Layer.BACKGROUND);
         }
         for (XYDataset dataset: this.datasets.values()) {
-            @SuppressWarnings("index") // guaranteed index: dataset is definitely a valid dataset, so its index will be nonnegative
+            @SuppressWarnings("index") // rewrite guaranteed index: dataset is definitely a valid dataset, so its index will be nonnegative
                     @NonNegative int datasetIndex = indexOf(dataset);
             drawRangeMarkers(g2, dataArea, datasetIndex, Layer.BACKGROUND);
         }
@@ -3647,7 +3647,7 @@ public class XYPlot extends Plot implements ValueAxisPlot, Pannable, Zoomable,
         // add domain axes to lists...
         for (ValueAxis axis : this.domainAxes.values()) {
             if (axis != null) {
-                @SuppressWarnings("index") // guaranteed index: axis is guaranteed to be a domain axis, so axisIndex is NN
+                @SuppressWarnings("index") // rewrite guaranteed index: axis is guaranteed to be a domain axis, so axisIndex is NN
                 @NonNegative int axisIndex = findDomainAxisIndex(axis);
                 axisCollection.add(axis, getDomainAxisEdge(axisIndex));
             }
@@ -3656,7 +3656,7 @@ public class XYPlot extends Plot implements ValueAxisPlot, Pannable, Zoomable,
         // add range axes to lists...
         for (ValueAxis axis : this.rangeAxes.values()) {
             if (axis != null) {
-                @SuppressWarnings("index") // guaranteed index: axis is guaranteed to be a range axis, so axisIndex is NN
+                @SuppressWarnings("index") // rewrite guaranteed index: axis is guaranteed to be a range axis, so axisIndex is NN
                 @NonNegative int axisIndex = findRangeAxisIndex(axis);
                 axisCollection.add(axis, getRangeAxisEdge(axisIndex));
             }
@@ -5327,7 +5327,7 @@ public class XYPlot extends Plot implements ValueAxisPlot, Pannable, Zoomable,
             if (dataset == null) {
                 continue;
             }
-            @SuppressWarnings("index") // guaranteed index: dataset is came from this object, so indexOf returns NN
+            @SuppressWarnings("index") // rewrite guaranteed index: dataset is came from this object, so indexOf returns NN
             @NonNegative int datasetIndex = indexOf(dataset);
             XYItemRenderer renderer = getRenderer(datasetIndex);
             if (renderer == null) {

--- a/src/main/java/org/jfree/chart/renderer/RendererUtils.java
+++ b/src/main/java/org/jfree/chart/renderer/RendererUtils.java
@@ -88,7 +88,6 @@ public class RendererUtils {
             // for the index of the highest x-value that is less than xLow
             @SuppressWarnings("index") // 0 is an index, because the item count is checked above and the function returns if there isn't at least one item
             @IndexFor("dataset.getSeries(series)") int low = 0;
-            @SuppressWarnings("index") // itemCount - 1 is an index, because the item count is checked above and the function returns if there isn't at least one item
             @IndexFor("dataset.getSeries(series)") int high = itemCount - 1;
             double lowValue = dataset.getXValue(series, low);
             if (lowValue >= xLow) {
@@ -117,7 +116,6 @@ public class RendererUtils {
             // bound is found by calculating relative to the xHigh value
             @SuppressWarnings("index") // 0 is an index, because the item count is checked above and the function returns if there isn't at least one item
             @IndexFor("dataset.getSeries(series)") int low = 0;
-            @SuppressWarnings("index") // itemCount - 1 is an index, because the item count is checked above and the function returns if there isn't at least one item
             @IndexFor("dataset.getSeries(series)") int high = itemCount - 1;
             double lowValue = dataset.getXValue(series, low);
             if (lowValue <= xHigh) {
@@ -186,7 +184,6 @@ public class RendererUtils {
         if (dataset.getDomainOrder() == DomainOrder.ASCENDING) {
             @SuppressWarnings("index") // 0 is an index, because the item count is checked above and the function returns if there isn't at least one item
             @IndexFor("dataset.getSeries(series)") int low = 0;
-            @SuppressWarnings("index") // itemCount - 1 is an index, because the item count is checked above and the function returns if there isn't at least one item
             @IndexFor("dataset.getSeries(series)") int high = itemCount - 1;
             double lowValue = dataset.getXValue(series, low);
             if (lowValue > xHigh) {
@@ -214,7 +211,6 @@ public class RendererUtils {
             // comparing against xLow
             @SuppressWarnings("index") // 0 is an index, because the item count is checked above and the function returns if there isn't at least one item
             @IndexFor("dataset.getSeries(series)") int low = 0;
-            @SuppressWarnings("index") // itemCount - 1 is an index, because the item count is checked above and the function returns if there isn't at least one item
             @IndexFor("dataset.getSeries(series)") int high = itemCount - 1;
             int mid = (low + high) / 2;
             double lowValue = dataset.getXValue(series, low);
@@ -242,7 +238,6 @@ public class RendererUtils {
             // but we can still skip any trailing values that fall outside the
             // range...
             int index = itemCount - 1;
-            @SuppressWarnings("index") // itemCount - 1 is an index, because the item count is checked above and the function returns if there isn't at least one item
             @IndexFor("dataset.getSeries(series)") int indexTmp = index;          // skip any items that don't need including...
             double x = dataset.getXValue(series, indexTmp);
             while (index >= 0 && x > xHigh) {

--- a/src/main/java/org/jfree/chart/renderer/category/CategoryItemRendererState.java
+++ b/src/main/java/org/jfree/chart/renderer/category/CategoryItemRendererState.java
@@ -206,12 +206,11 @@ public class CategoryItemRendererState extends RendererState {
      * 
      * @since 1.0.13
      */
-    @SuppressWarnings("index") // this.visibleSeries only contains nonnegatives. The result array is a copy of this array
     public @NonNegative int[] getVisibleSeriesArray() {
         if (this.visibleSeries == null) {
             return null;
         }
-        int[] result = new int[this.visibleSeries.length];
+        @NonNegative int[] result = new int[this.visibleSeries.length];
         System.arraycopy(this.visibleSeries, 0, result, 0,
                 this.visibleSeries.length);
         return result;

--- a/src/main/java/org/jfree/chart/renderer/xy/CyclicXYItemRenderer.java
+++ b/src/main/java/org/jfree/chart/renderer/xy/CyclicXYItemRenderer.java
@@ -361,7 +361,6 @@ public class CyclicXYItemRenderer extends StandardXYItemRenderer
          * @param y  the y values.
          * @param delegateSet  the dataset.
          */
-        @SuppressWarnings("index") // SameLen on custom collections requires a suppressed warning to establish representation invariant https://github.com/kelloggm/checker-framework/issues/213
         public OverwriteDataSet(double @SameLen("#2") [] x, double @SameLen("#1") [] y,
                                 XYDataset delegateSet) {
             this.delegateSet = delegateSet;

--- a/src/main/java/org/jfree/data/general/DatasetUtils.java
+++ b/src/main/java/org/jfree/data/general/DatasetUtils.java
@@ -2287,7 +2287,6 @@ public final class DatasetUtils {
             return Double.NaN;
         }
 
-        @SuppressWarnings("index") // guaranteed index: the check above is sufficient to establish that no entries in indices are negative, since the values are correlated.
         @IndexFor("dataset.getSeries(series)") int indices0 = indices[0];
 
         @SuppressWarnings("index") // guaranteed index: the check above is sufficient to establish that no entries in indices are negative, since the values are correlated.

--- a/src/main/java/org/jfree/data/general/DatasetUtils.java
+++ b/src/main/java/org/jfree/data/general/DatasetUtils.java
@@ -2343,7 +2343,6 @@ public final class DatasetUtils {
         if (dataset.getDomainOrder() == DomainOrder.ASCENDING) {
             @SuppressWarnings("index") // 0 is a valid index, because itemCount > 1
             @IndexFor("dataset.getSeries(series)") int low = 0;
-            @SuppressWarnings("index") // itemCount - 1 is an index, because itemCount > 1
             @IndexFor("dataset.getSeries(series)") int high = itemCount - 1;
             double lowValue = dataset.getXValue(series, low);
             if (lowValue > x) {
@@ -2378,7 +2377,6 @@ public final class DatasetUtils {
         else if (dataset.getDomainOrder() == DomainOrder.DESCENDING) {
             @SuppressWarnings("index") // 0 is a valid index, because itemCount > 1
             @IndexFor("dataset.getSeries(series)") int high = 0;
-            @SuppressWarnings("index") // itemCount - 1 is an index, because itemCount > 1
             @IndexFor("dataset.getSeries(series)") int low = itemCount - 1;
             double lowValue = dataset.getXValue(series, low);
             if (lowValue > x) {

--- a/src/main/java/org/jfree/data/io/CSV.java
+++ b/src/main/java/org/jfree/data/io/CSV.java
@@ -172,7 +172,6 @@ public class CSV {
                         (Comparable) columnKeys.get(fieldIndex - 1)
                     );
                 }
-                @SuppressWarnings("index") // line is CSV formatted, so skipping is okay here
                 @IndexOrHigh("line") int skipIndex = i + 1;
                 start = skipIndex;
                 fieldIndex++;

--- a/src/main/java/org/jfree/data/statistics/DefaultBoxAndWhiskerXYDataset.java
+++ b/src/main/java/org/jfree/data/statistics/DefaultBoxAndWhiskerXYDataset.java
@@ -216,7 +216,6 @@ public class DefaultBoxAndWhiskerXYDataset extends AbstractXYDataset
      * @return The number of items in the specified series.
      */
     @Override
-    @SuppressWarnings("index") // array-list interop: the underlying data structure here is a list, but this method's annotation expects an array
     public @LengthOf("this.getSeries(#1)") int getItemCount(@NonNegative int series) {
         return this.dates.size();
     }

--- a/src/main/java/org/jfree/data/statistics/HistogramDataset.java
+++ b/src/main/java/org/jfree/data/statistics/HistogramDataset.java
@@ -338,7 +338,6 @@ public class HistogramDataset extends AbstractIntervalXYDataset
      *     specified range.
      */
     @Override
-    @SuppressWarnings("index") // array-list interop: the underlying data structure here is a list, but this method's annotation expects an array
     public @LengthOf("this.getSeries(#1)") int getItemCount(@NonNegative int series) {
         return getBins(series).size();
     }

--- a/src/main/java/org/jfree/data/statistics/SimpleHistogramDataset.java
+++ b/src/main/java/org/jfree/data/statistics/SimpleHistogramDataset.java
@@ -166,7 +166,6 @@ public class SimpleHistogramDataset extends AbstractIntervalXYDataset
      * @return The item count.
      */
     @Override
-    @SuppressWarnings("index") // array-list interop: the underlying data structure here is a list, but this method's annotation expects an array
     public @LengthOf("this.getSeries(#1)") int getItemCount(@NonNegative int series) {
         return this.bins.size();
     }

--- a/src/main/java/org/jfree/data/xy/DefaultIntervalXYDataset.java
+++ b/src/main/java/org/jfree/data/xy/DefaultIntervalXYDataset.java
@@ -483,7 +483,6 @@ public class DefaultIntervalXYDataset extends AbstractIntervalXYDataset
      * @return A boolean.
      */
     @Override
-    @SuppressWarnings("index") // array-list interop: Equality test relies on well-formedness of other object, which can't be annotated perfectly because of array-list interop
     public boolean equals(Object obj) {
         if (obj == this) {
             return true;
@@ -554,7 +553,6 @@ public class DefaultIntervalXYDataset extends AbstractIntervalXYDataset
      *         a key that cannot be cloned.
      */
     @Override
-    @SuppressWarnings("index") // clone assumes that the dataset is well-formed.
     public Object clone() throws CloneNotSupportedException {
         DefaultIntervalXYDataset clone
                 = (DefaultIntervalXYDataset) super.clone();

--- a/src/main/java/org/jfree/data/xy/DefaultWindDataset.java
+++ b/src/main/java/org/jfree/data/xy/DefaultWindDataset.java
@@ -189,7 +189,6 @@ public class DefaultWindDataset extends AbstractXYDataset
      * @return The item count.
      */
     @Override
-    @SuppressWarnings("index") // array-list interop: the annotation here expects this to be backed by a list of arrays, but its backed by a list of lists
     public @LengthOf("this.getSeries(#1)") int getItemCount(@NonNegative int series) {
         if (series < 0 || series >= getSeriesCount()) {
             throw new IllegalArgumentException("Invalid series index: "

--- a/src/main/java/org/jfree/data/xy/XYBarDataset.java
+++ b/src/main/java/org/jfree/data/xy/XYBarDataset.java
@@ -126,7 +126,6 @@ public class XYBarDataset extends AbstractIntervalXYDataset
      * @return The series count.
      */
     @Override
-    @SuppressWarnings("index") // retain information when casting https://github.com/kelloggm/checker-framework/issues/212
     public @NonNegative int getSeriesCount() {
         return this.underlying.getSeriesCount();
     }


### PR DESCRIPTION
1. Remove two warning suppressions that aren't required.  (One required more annotations.)
2. Added "rewrite" to 14 of the false positives that could be fixed by using Map.Entry.
3. Remove 16 more warning suppressions that aren't required.